### PR TITLE
Fix a record

### DIFF
--- a/bin/cli/actions/deploy.ts
+++ b/bin/cli/actions/deploy.ts
@@ -200,7 +200,7 @@ export default async function handleDeployCommand() {
       if (hostingConfiguration.hostedZoneId) {
         const cFCNAMEExists = await checkCFCNAMEExists(
           hostingConfiguration.domainName,
-          domainName.substring(8),
+          domainName,
           hostingConfiguration.hostedZoneId
         );
 
@@ -209,7 +209,7 @@ export default async function handleDeployCommand() {
           if (associate.value == "yes") {
             await createCFCNAME(
               hostingConfiguration.domainName,
-              domainName.substring(8),
+              domainName,
               hostingConfiguration.hostedZoneId
             );
           }
@@ -239,7 +239,7 @@ export default async function handleDeployCommand() {
         console.log(
           `>           Host name: ${hostingConfiguration.domainName}`
         );
-        console.log(`>           Target: ${domainName.substring(8)}`);
+        console.log(`>           Target: ${domainName}`);
         console.log(">       Save your changes.");
 
         console.log("\n");

--- a/bin/cli/actions/deploy.ts
+++ b/bin/cli/actions/deploy.ts
@@ -206,9 +206,7 @@ export default async function handleDeployCommand() {
 
         if (!cFCNAMEExists) {
           const associate = await startPrompt(cloudFrontAssociationQuestion);
-          console.log("associate.value="+associate.value)
           if (associate.value == "yes") {
-            console.log("here")
             await createCFCNAME(
               hostingConfiguration.domainName,
               domainName.substring(8),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: 4**

## Summary
Ensure full Cloudfront domain name is used when creating the A record in Route53, addressing a bug where the A record created for custom domain names targets a substring of the Cloudfront domain name.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
