### PR TITLE
Properly bundles package before publishing to npm. fix #8

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,8 +16,7 @@ jobs:
           node-version: 20
       - run: npm install
       - run: npm run build
-      - run: cp cdk.json.built cdk.json      
-      - run: cp cdk.json.built cdk.json      
+      - run: cp cdk.json.built cdk.json     
 
   publish-npm:
     needs: build
@@ -28,6 +27,8 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm run build
       - run: npm pack
       - run: npm publish --access=public
         env:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #8 

## Summary

It looks like the current publish process does not build before packaging, so all the `.js` files are missing (see #8)

### Changes

Adds the `npm i` and `npm run build` steps before `npm publish` in the `npm-publish.yml` workflow

### User experience

n/d

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested (hard to test actions :/ )
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
