### PR TITLE
fix: update domain name regex to accept longer TLDs (#19)

### DIFF
--- a/bin/cli/shared/constants.ts
+++ b/bin/cli/shared/constants.ts
@@ -51,7 +51,8 @@ export const CLOUDFRONT_HOSTEDZONE_ID = "Z2FDTNDATAQYW2";
 export const GITHUB_REGEX =
   /^((https:\/\/github\.com\/([^/]+)\/([^/]+))|(git@github\.com:([^/]+)\/([^/]+)))\.git$/;
 export const DOMAIN_NAME_REGEX =
-  /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/i;
+  /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}$/i;
+  
 
 export const ERROR_PREFIX = "\n\n[ERROR]";
 


### PR DESCRIPTION
- Modified regex pattern to accept TLDs longer than 6 characters
- Changed TLD length limit from {2,6} to {2,}
- Allows domains like .services to be validated correctly

Fixes #19

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
